### PR TITLE
Feature/SQLite persistence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ walkdir = "2.4"
 rayon = "1.8"
 tempfile = "3.8"
 rusqlite = "0.37.0"
+sha2 = "0.10.9"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ futures = "0.3"
 walkdir = "2.4"
 rayon = "1.8"
 tempfile = "3.8"
+rusqlite = "0.37.0"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,72 @@ Set timeout and parallel jobs:
 bcore-mutation analyze -j 8 -t 300 --survival-threshold 0.3
 ```
 
+### Storage
+
+Performed during the mutants generation (`mutation` command)
+
+Store generated mutants in the `db` folder (create if does not exists).
+Default folder: `mutation.db`: 
+
+```bash
+bcore-mutation mutate <options> --sqlite <db_name> 
+```
+
+### Examples:
+
+For a specific file, using the default database(`mutation.db`):
+
+```bash
+bcore-mutation mutate -f src/wallet/wallet.cpp --sqlite 
+```
+
+For a specific PR with custom database(`results.db`):
+
+```bash
+bcore-mutation mutate -p 12345 --sqlite results.db
+```
+
+### Update Storage
+
+Performed during the mutant analysis (`analyze` command)
+
+Perform full analysis for a specific run id (obligatory):
+
+```bash
+bcore-mutation analyze --sqlite --runid <run id number>
+```
+
+Perform analysis for a specific file:
+
+```bash
+bcore-mutation analyze -f <file name> --sqlite --run_id <run id number>
+```
+
+Perform analysis for a specific file with custom command to test:
+
+```bash
+bcore-mutation analyze -f <file name> --sqlite --run_id <run id number> -c <command to test>
+```
+
+### Examples:
+
+For general analysis, on run id 10:
+
+```bash
+bcore-mutation analyze --sqlite --run_id 10
+```
+
+Analysis on the muts-pr-wallet-1-150 folder generated on run id 1:
+
+```bash
+bcore-mutation analyze -f muts-pr-wallet-1-150 --sqlite --run_id 1
+```
+
+Perform analysis for muts-pr-wallet-1-150 folder of run id 2 with custom command `cmake --build build`:
+
+```bash
+bcore-mutation analyze -f muts-pr-wallet-1-150 --sqlite --run_id 2 -c "cmake --build build"
+
 ## Library Usage
 
 The tool can also be used as a Rust library:

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -35,7 +35,7 @@ pub async fn run_analysis(
     Ok(())
 }
 
-fn find_mutation_folders() -> Result<Vec<PathBuf>> {
+pub fn find_mutation_folders() -> Result<Vec<PathBuf>> {
     let mut folders = Vec::new();
 
     for entry in WalkDir::new(".").max_depth(1) {

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -155,7 +155,9 @@ pub async fn analyze_folder(
             }
             num_killed += 1
         }
-        update_command_to_test_mutant(&test_command, &file_path, db_path.clone(), run_id.clone().unwrap())?;
+        if let Some(db_path) = db_path.clone() {
+            update_command_to_test_mutant(&test_command, &file_path, db_path, run_id.clone().unwrap_or_default())?;
+        }
     }
 
     // Generate report

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,9 @@ pub enum MutationError {
     #[error("SQLite error: {0}")]
     Sqlite(#[from] rusqlite::Error),
 
+    #[error("Db path error")]
+    MissingDbPath,
+
     #[error("Other error: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,9 @@ pub enum MutationError {
     #[error("Walkdir error: {0}")]
     Walkdir(#[from] walkdir::Error),
 
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
     #[error("Other error: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/src/git_changes.rs
+++ b/src/git_changes.rs
@@ -82,6 +82,17 @@ pub async fn get_lines_touched(file_path: &str) -> Result<Vec<usize>> {
     Ok(lines)
 }
 
+pub fn get_commit_hash() -> Result<String> {
+
+    let commit_hash = Command::new("git")
+    .args(["rev-parse", "HEAD"])
+    .output()
+    .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+    .unwrap_or_else(|_| "unknown".to_string());
+
+    Ok(commit_hash)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 //! }
 //! ```
 
+pub mod sqlite;
 pub mod analyze;
 pub mod ast_analysis;
 pub mod coverage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,7 @@ async fn main() -> Result<()> {
 
             mutation::run_mutation(
                 if pr == 0 { None } else { Some(pr) },
-                file,
+                file.clone(),
                 one_mutant,
                 only_security_mutations,
                 range_lines,
@@ -183,8 +183,11 @@ async fn main() -> Result<()> {
             .await?;
 
             if let Some(ref path) = db_path {
-                sqlite::store_mutants(path, run_id).map_err(Error::from)?;
-
+                sqlite::store_mutants(
+                    path,
+                    run_id,
+                    if pr == 0 { None } else { Some(pr) },
+                    file).map_err(Error::from)?;
             }
 
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,7 +210,7 @@ async fn main() -> Result<()> {
             runid,
         } => {
 
-            let db_path = match sqlite {
+            let db_path = match sqlite.clone() {
                 Some(Some(path)) => {
                     let mut full_path = PathBuf::from("db");
                     full_path.push(path);
@@ -220,16 +220,18 @@ async fn main() -> Result<()> {
                 None => None,
             };
 
-            if runid.is_none() {
-                return Err(MutationError::InvalidInput(
-                    "--sqlite requires --runid".to_string(),
-                ));
-            }
+            if sqlite.is_some() {
+                if runid.is_none() {
+                    return Err(MutationError::InvalidInput(
+                        "--sqlite requires --runid".to_string(),
+                    ));
+                }
 
-            if runid.is_some() && db_path.is_none() {
-                return Err(MutationError::InvalidInput(
-                    "--runid requires --sqlite".to_string(),
-                ));
+                if runid.is_some() && db_path.is_none() {
+                    return Err(MutationError::InvalidInput(
+                        "--runid requires --sqlite".to_string(),
+                    ));
+                }
             }
 
             analyze::run_analysis(folder, command, jobs, timeout, survival_threshold, db_path, runid).await?;

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1,0 +1,265 @@
+use rusqlite::params;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use rusqlite::{Connection, Result};
+
+use crate::git_changes::{get_commit_hash};
+
+
+pub fn store_mutants(db_path: &PathBuf, run_id: i64) -> Result<()> {
+    
+    println!("SQLite option: Storing mutants on {}", db_path.display());
+    let connection = Connection::open(db_path)?;
+
+
+
+
+    //run_id
+    println!("run_id: {}", run_id.to_string());
+    //diff
+    //patch_hash
+    //command_to_test
+    //file_path
+    //operator
+
+    /*
+    connection.execute("
+
+        INSERT INTO  mutants (run_id , diff, patch_hash, command_to_test, file_path, operator)
+        VALUES (?1, ?2, ?3, ?4);
+    ", params![run_id, commit_hash, pr_number, tool_version],)?;
+    */
+    //Filling mutants table
+
+
+
+    // Fazer preenchimento da ultima tabela (mutants)
+    // TODO fill tables with run
+    // TODO test functionality
+    // TODO script test
+
+    Ok(())
+}
+
+
+
+pub fn store_run(db_path: &PathBuf, pr_number: Option<u32>) -> Result<i64> {
+
+    println!("SQLite option: Storing current run on {}", db_path.display());
+    let connection = Connection::open(db_path)?;
+
+    let proj_query_row: (i32, String) = connection.query_row(
+        "SELECT id, name FROM projects;",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?))
+    )?;
+
+    let project_id = proj_query_row.0;
+    println!("id: {}", project_id);
+    
+    /*
+    let commit_hash = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+*/
+  
+    let commit_hash = match get_commit_hash() {
+        Ok(hash) => hash,
+        Err(_) => "unknown".to_string(),
+    };
+
+    println!("commit hash: {}", commit_hash);
+
+    let tool_version = format!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    
+    connection.execute("
+
+        INSERT INTO  runs (project_id , commit_hash, pr_number, tool_version)
+        VALUES (?1, ?2, ?3, ?4);
+    ", params![project_id, commit_hash, pr_number, tool_version],)?;
+    
+    let run_id = connection.last_insert_rowid();
+
+    Ok(run_id)
+}
+
+fn _check_initial_row(connection: &Connection) -> Result<()> {
+    println!("SQLite option: Checking first row of projects...");
+
+    let result = connection.query_row(
+        "SELECT id, name, repository_url FROM projects WHERE id = 1;",
+        [],
+        |row| Ok((row.get::<_, i32>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+    );
+
+    match result {
+        Ok((id, name, repo)) => {
+            if id == 1 && name == "Bitcoin Core" && repo == "https://github.com/bitcoin/bitcoin" {
+                println!("SQLite option: Project table corrected filled!");
+            }
+        },
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            println!("SQLite option: No matches found for projects table, filling initial row...");
+            _fill_projects_table(&connection)?;
+        },
+        Err(e) => {
+            eprintln!("SQLite option: FAILED to verify initial project: {}", e);
+            return Err(e);
+        }
+    }
+
+    Ok(())
+}
+
+fn _fill_projects_table(connection: &Connection) -> Result<()> {
+    connection.execute("
+        ---First time initialization
+        INSERT OR IGNORE INTO projects (id, name, repository_url)
+        VALUES (1, 'Bitcoin Core', 'https://github.com/bitcoin/bitcoin');
+    ", [])?;
+
+    Ok(())
+}
+
+fn _check_schema(connection: &Connection) -> Result<()> {
+    println!("SQLite option: Checking schema integrity...");
+
+    let expected_tables = vec!["projects", "runs", "mutants"];
+    for table in expected_tables {
+        let exists: bool = connection.query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1;",
+            params![table],
+            |row| row.get(0),
+        )?;
+
+        if !exists {
+            return Err(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(1),
+                Some(format!("Missing table: {}", table)),
+            ));
+        }
+    }
+
+    // Verificação de colunas essenciais por tabela (incluindo colunas virtuais)
+    let table_columns: Vec<(&str, Vec<&str>)> = vec![
+        ("projects", vec!["id", "name", "repository_url"]),
+        ("runs", vec!["id", "project_id", "commit_hash", "pr_number", "created_at", "tool_version"]),
+        ("mutants", vec![
+            "id", "run_id", "diff", "patch_hash", "status", "killed", 
+            "command_to_test", "file_path", "operator"
+        ]),
+    ];
+
+    for (table, columns) in table_columns {
+        let mut stmt = connection.prepare(&format!("PRAGMA table_xinfo({});", table))?;
+        let column_names: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))? 
+            .filter_map(Result::ok)
+            .collect();
+
+        for col in columns {
+            if !column_names.contains(&col.to_string()) {
+                return Err(rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error::new(1),
+                    Some(format!("Missing column '{}' in table '{}'", col, table)),
+                ));
+            }
+        }
+    }
+
+    println!("SQLite option: Schema verified successfully.");
+    Ok(())
+}
+
+fn _createdb(connection: &Connection) -> Result<()> {
+    println!("SQLite option:: New db detected initializing first fillment...");
+
+    // DB tables creation
+    connection.execute_batch("
+        PRAGMA foreign_keys = ON;
+        
+        -- Projects
+        CREATE TABLE IF NOT EXISTS projects (
+        id              INTEGER PRIMARY KEY,
+        name            TEXT NOT NULL,
+        repository_url  TEXT,
+        UNIQUE(name),
+        UNIQUE(repository_url)
+        );
+
+        --Runs
+        CREATE TABLE IF NOT EXISTS runs (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+            commit_hash     TEXT NOT NULL,
+            pr_number       INTEGER,
+            created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            tool_version    TEXT,
+            FOREIGN KEY(project_id) REFERENCES projects(id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_runs_project_created ON runs(project_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_runs_commit ON runs(commit_hash);
+
+        CREATE TABLE IF NOT EXISTS mutants (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id INTEGER NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+            diff                TEXT NOT NULL,
+            patch_hash          TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending'
+                CHECK (status IN ('pending','running','killed','survived','timeout','error','skipped','equivalent','unproductive')),
+            killed INTEGER GENERATED ALWAYS AS (CASE WHEN status='killed' THEN 1 ELSE 0 END) VIRTUAL,
+            command_to_test     TEXT,
+            file_path           TEXT NOT NULL,
+            operator            TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES runs(id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_mutants_run_status ON mutants(run_id, status);
+        CREATE INDEX IF NOT EXISTS idx_mutants_file ON mutants(file_path);
+        CREATE INDEX IF NOT EXISTS idx_mutants_operator ON mutants(operator);
+        CREATE INDEX IF NOT EXISTS idx_mutants_killed ON mutants(killed);
+
+    ")?;
+
+    println!("SQLite option: Ok batch");
+
+    //Filling projects table
+    _fill_projects_table(&connection)?;
+
+    Ok(())
+}
+
+pub fn check_db(db_path: &PathBuf) -> Result<()> {
+    
+    println!("SQLite option: Checking if db exist...");
+    let is_new_db = !db_path.exists();
+    
+    //Verify path integrity
+    let exist_path = Path::new("db");
+    if !exist_path.exists() {
+        match fs::create_dir_all(exist_path) {
+            Ok(_) => {},
+            Err(e) => {
+                eprintln!("FAIL creating new folder db: {}", e);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let connection = Connection::open(db_path)?;
+    
+    if is_new_db {
+        _createdb(&connection)?;
+
+    } else {
+        println!("SQLite option: Current db exists!");
+        _check_schema(&connection)?;
+        _check_initial_row(&connection)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
SQLite feature developed based on https://github.com/brunoerg/bcore-mutation/issues/11

*Development Summary:

------------------------------------------------
[sqlite.rs file (NEW FILE)]:

Implemented the following functions:

- check_db
- _createdb
- _check_schema
- _fill_projects_table
- _check_initial_row
- store_run
- store_mutants
- check_mutation_folder
- get_files_from_folder
- get_file_diff
- get_hash_from_diff
- update_status_mutant
- update_command_to_test_mutant
- update_mutants_table

Implemented the following tests:

- test_db_creation_and_seed
- test_store_run_creates_row
- test_store_mutants_inserts_rows
- test_update_status_mutant
- test_update_command_mutant

------------------------------------------------
[main.rs file (MODIFICATIONS)]:

Implemented the following logic:

- Added mod sqlite.rs
- Optional SQLite flag for mutation + handler
- Optional SQLite flag for analyze with --run_id + handler

------------------------------------------------
[lib.rs file (MODIFICATIONS)]:

- sqlite.rs module

------------------------------------------------
[git_changes.rs file (MODIFICATIONS)]:

- get_commit_hash function implementation

------------------------------------------------
[error.rs file (MODIFICATIONS)]:

- Added Sqlite and MissingDbPath errors

------------------------------------------------
[analyze.rs file (MODIFICATIONS)]:

- Adapted run_analysis signature to get db_path and run_id
- Added update_status_mutant and update_command_to_test_mutant on current logic
- Changed find_mutation_folders visibility to public so it can be called from the sqlite.rs module

------------------------------------------------
[Cargo.toml file (MODIFICATIONS)]:

- Added rusqlite and sha2 dependencies 

-------------------------------------------------------------------------------------------
*Additional comments:

 - strategy, config_json from the current execution config -> NOT IMPLEMENTED
 - The database schema follows the issue documentation entirely, with only one exception on table mutant that was inserted an additional column called file_name to query on analyze section
 - Apart from the code tests, the following functional tests were performed manually:
	
	- (mutate) -> --sqlite flag optional, normal behavior {OK}
	- (mutate --sqlite <without db>) -> Creates/open "db/mutation.db" and uses it {OK}
	- (mutate --sqlite results.db) -> Creates/open "db/results.db" and uses it {OK}
	- (mutate --sqlite ...) -> Verify INSERT OR IGNORE INTO projects (name, repository_url) VALUES ('Bitcoin Core', 'https://github.com/bitcoin/bitcoin'); {OK}
	- (mutate --sqlite...) -> General behavior: Open DB (create if missing) Ensure projects seed (bitcoin core), create run, insert mutants {OK}

	- (analyze --sqlite) -> Asks for run_id {OK}
	- (analyze --sqlite <db_file> <run_id> <without command>) -> Record standard commands {OK}
	- (analyze <without file (-f ...)> --sqlite <run_id> ...) -> Record only for run_id, behave like analyze normally {OK}

-------------------------------------------------------------------------------------------
*Further implementations suggestion:

 - Modify logic when grabbing file extensions (current supports only for .cpp, .h and .py files)
 - Implement help options for flag --sqlite
 - Insert one more table column on table runs indicating the total number of mutants generated
 - Explore options for compress the data on column "diff" on table "mutants" if diffs become hard to store and read
 - Implement a folder called bcore-mutation on the project that it's running to hold "db" and "mutants" folders apart from original project